### PR TITLE
Add config option to require power for EM Rail Ejector

### DIFF
--- a/src/generated/resources/assets/dysoncubeproject/lang/en_us.json
+++ b/src/generated/resources/assets/dysoncubeproject/lang/en_us.json
@@ -32,5 +32,6 @@
   "itemGroup.dyson_cube_project": "Dyson Cube Project",
   "tooltip.dysoncubeproject.contains_beams": "Contains %s beam(s)",
   "tooltip.dysoncubeproject.contains_solar_sails": "Contains %s solar sail(s)",
-  "tooltip.dysoncubeproject.power_optional": "*Power Optional, with power it allows to ramp up how many beams/sails are ejected*"
+  "tooltip.dysoncubeproject.power_optional": "*Power Optional, with power it allows to ramp up how many beams/sails are ejected*",
+  "tooltip.dysoncubeproject.power_mandatory": "*Power Mandatory, with power it allows to ramp up how many beams/sails are ejected*"
 }

--- a/src/main/java/com/buuz135/dysoncubeproject/Config.java
+++ b/src/main/java/com/buuz135/dysoncubeproject/Config.java
@@ -36,4 +36,7 @@ public class Config {
     @ConfigVal(comment = "The power that the em railejector consumes each tick per sent item")
     @ConfigVal.InRangeInt(min = 1)
     public static int RAIL_EJECTOR_CONSUME = 40;
+
+    @ConfigVal(comment = "Set to 'true' to require power for the em railejector to semd items")
+    public static bool RAIL_EJECTOR_REQUIRES_POWER = false;
 }

--- a/src/main/java/com/buuz135/dysoncubeproject/Config.java
+++ b/src/main/java/com/buuz135/dysoncubeproject/Config.java
@@ -37,6 +37,6 @@ public class Config {
     @ConfigVal.InRangeInt(min = 1)
     public static int RAIL_EJECTOR_CONSUME = 40;
 
-    @ConfigVal(comment = "Set to 'true' to require power for the em railejector to semd items")
-    public static bool RAIL_EJECTOR_REQUIRES_POWER = false;
+    @ConfigVal(comment = "Set to 'true' to require power for the em railejector to send items")
+    public static boolean RAIL_EJECTOR_REQUIRES_POWER = false;
 }

--- a/src/main/java/com/buuz135/dysoncubeproject/block/tile/EMRailEjectorBlockEntity.java
+++ b/src/main/java/com/buuz135/dysoncubeproject/block/tile/EMRailEjectorBlockEntity.java
@@ -81,7 +81,7 @@ public class EMRailEjectorBlockEntity extends BasicTile<EMRailEjectorBlockEntity
         super(base, blockEntityType, pos, state);
         this.progressBarComponent = new ProgressBarComponent<EMRailEjectorBlockEntity>(45, 21, 120)
                 .setCanIncrease(iComponentHarness -> this.canIncrease()).setOnTickWork(() -> {
-            syncObject(this.progressBarComponent);
+                    syncObject(this.progressBarComponent);
                 })
                 .setOnFinishWork(this::onFinishWork)
                 .setIncreaseType(true)
@@ -118,8 +118,7 @@ public class EMRailEjectorBlockEntity extends BasicTile<EMRailEjectorBlockEntity
         var beams = this.input.getStackInSlot(0).getOrDefault(DCPAttachments.BEAM, 0);
         if (solarPanels > 0 && (dyson.getSolarPanels() + solarPanels) > dyson.getMaxSolarPanels()) return false;
         if (beams > 0 && dyson.getBeams() >= dyson.getMaxBeams()) return false;
-        if (this.rampupAmount > 1 && this.getPower().getEnergyStored() < (Math.pow(this.rampupAmount, 2) * Config.RAIL_EJECTOR_CONSUME)) {
-            this.rampupAmount = 1;
+        if ((Config.RAIL_EJECTOR_REQUIRES_POWER || this.rampupAmount > 1) && this.getPower().getEnergyStored() < (Math.pow(this.rampupAmount, 2) * Config.RAIL_EJECTOR_CONSUME)) {
             return false;
         }
 
@@ -169,10 +168,14 @@ public class EMRailEjectorBlockEntity extends BasicTile<EMRailEjectorBlockEntity
             }
 
             progressBarComponent.tickBar();
+        } else {
+            if (this.cooldown <= 0) {
+                this.rampupAmount = 1;
+            }
 
-
-        } else if (progressBarComponent.getCanReset().test(progressBarComponent.getComponentHarness())) {
-            progressBarComponent.setProgress(progressBarComponent.getIncreaseType() ? 0 : progressBarComponent.getMaxProgress());
+            if (progressBarComponent.getCanReset().test(progressBarComponent.getComponentHarness())) {
+                progressBarComponent.setProgress(progressBarComponent.getIncreaseType() ? 0 : progressBarComponent.getMaxProgress());
+            }
         }
 
         if (this.cooldown > 0) this.cooldown--;
@@ -186,7 +189,6 @@ public class EMRailEjectorBlockEntity extends BasicTile<EMRailEjectorBlockEntity
         if (this.targetPitch >= 360 - 10) {
             this.targetPitch = 10;
         }
-
 
         if (this.targetPitch <= 90) {
             this.targetYaw = 0;

--- a/src/main/java/com/buuz135/dysoncubeproject/client/ClientSetup.java
+++ b/src/main/java/com/buuz135/dysoncubeproject/client/ClientSetup.java
@@ -1,5 +1,6 @@
 package com.buuz135.dysoncubeproject.client;
 
+import com.buuz135.dysoncubeproject.Config;
 import com.buuz135.dysoncubeproject.DCPAttachments;
 import com.buuz135.dysoncubeproject.DCPContent;
 import com.buuz135.dysoncubeproject.DysonCubeProject;
@@ -51,7 +52,7 @@ public class ClientSetup {
                         .withColor(DCPContent.CYAN_COLOR));
             }
             if (stack.is(DCPContent.Blocks.EM_RAILEJECTOR_CONTROLLER.asItem())) {
-                itemTooltipEvent.getToolTip().add(Component.translatable("tooltip.dysoncubeproject.power_optional")
+                itemTooltipEvent.getToolTip().add(Component.translatable(Config.RAIL_EJECTOR_REQUIRES_POWER ? "tooltip.dysoncubeproject.power_mandatory" : "tooltip.dysoncubeproject.power_optional")
                         .withColor(DCPContent.CYAN_COLOR));
             }
         }).subscribe();

--- a/src/main/java/com/buuz135/dysoncubeproject/datagen/DCPLangItemProvider.java
+++ b/src/main/java/com/buuz135/dysoncubeproject/datagen/DCPLangItemProvider.java
@@ -42,6 +42,7 @@ public class DCPLangItemProvider extends LanguageProvider {
         this.add("tooltip.dysoncubeproject.contains_solar_sails", "Contains %s solar sail(s)");
         this.add("tooltip.dysoncubeproject.contains_beams", "Contains %s beam(s)");
         this.add("tooltip.dysoncubeproject.power_optional", "*Power Optional, with power it allows to ramp up how many beams/sails are ejected*");
+        this.add("tooltip.dysoncubeproject.power_mandatory", "*Power Mandatory, with power it allows to ramp up how many beams/sails are ejected*");
         formatAdvancement("root.title", "Dyson Cube Project");
         formatAdvancement("root.description", "TODAY WE STEAL THE SUN!");
         var amounts = new int[]{5, 15, 25, 50, 75, 100};

--- a/src/main/resources/assets/dysoncubeproject/lang/pt_br.json
+++ b/src/main/resources/assets/dysoncubeproject/lang/pt_br.json
@@ -17,5 +17,6 @@
   "itemGroup.dyson_cube_project": "Projeto Cubo de Dyson",
   "tooltip.dysoncubeproject.contains_beams": "Contém %s raio(s)",
   "tooltip.dysoncubeproject.contains_solar_sails": "Contém %s vela(s) solar(es)",
-  "tooltip.dysoncubeproject.power_optional": "*Energia Opcional, com energia permite aumentar quantos vaios/velas são ejetados*"
+  "tooltip.dysoncubeproject.power_optional": "*Energia Opcional, com energia permite aumentar quantos vaios/velas são ejetados*",
+  "tooltip.dysoncubeproject.power_mandatory": "*Energia Obrigatória, com energia permite aumentar quantos vaios/velas são ejetados*"
 }

--- a/src/main/resources/assets/dysoncubeproject/lang/zh_cn.json
+++ b/src/main/resources/assets/dysoncubeproject/lang/zh_cn.json
@@ -17,5 +17,6 @@
   "itemGroup.dyson_cube_project": "戴森立方计划",
   "tooltip.dysoncubeproject.contains_beams": "包含%s个结构梁",
   "tooltip.dysoncubeproject.contains_solar_sails": "包含%s个太阳帆",
-  "tooltip.dysoncubeproject.power_optional": "*能量为可选项，提供能量可提升弹射结构梁/太阳帆的数量*"
+  "tooltip.dysoncubeproject.power_optional": "*能量为可选项，提供能量可提升弹射结构梁/太阳帆的数量*",
+  "tooltip.dysoncubeproject.power_mandatory": "*能量为必选项，提供能量可提升弹射结构梁/太阳帆的数量*"
 }


### PR DESCRIPTION
Adds a new boolean RAIL_EJECTOR_REQUIRES_POWER config option, which when enabled forces you to provide power to the EM Rail Ejector for it to send items
Made the tooltip change when the config is on (Same text but replaced "Optional" with "Mandatory"; Unsure about chinese translation as I don't speak the language)

Additionally fixed rampup not resetting when an operation is interrupted by a non-power condition. Previously if the ejector was interrupted by something like rain, the rampup wouldn't be reset (rain, night, sky access, no items, max panels, etc.). Rampup would only ever be reset if all the conditions to launch are met, but no power is available.